### PR TITLE
Fixed errors with UINT in PodCommands and BasicPodProtocol

### DIFF
--- a/src/Morelia/Commands/PodCommands.py
+++ b/src/Morelia/Commands/PodCommands.py
@@ -126,9 +126,9 @@ class CommandSet :
                 argument ASCII bytes, number of return bytes, binary flag, description) }.
         """
         # constants 
-        UINT8  = CommandSet.UINT8()
-        UINT16 = CommandSet.UINT16()
-        NO_VALUE = CommandSet.NoValue()
+        UINT8  = CommandSet.get_uint8()
+        UINT16 = CommandSet.get_uint16()
+        NO_VALUE = CommandSet.no_value()
         # basic standard POD commands 
         basics = { # key(command number) : value([command name, (number of argument ASCII hex chars), (number of return ASCII hex chars), binary flag, description]), 
             0  : [ 'ACK',               (0,),   (0,),        False,  'Deprecated in favor of responding with the command number received.'                    ],

--- a/src/Morelia/Devices/BasicPodProtocol.py
+++ b/src/Morelia/Devices/BasicPodProtocol.py
@@ -56,10 +56,10 @@ class Pod :
         :return: number of hexadecimal characters for an unsigned u-bit value.
         """
         match u : 
-            case  8: return(CommandSet.UINT8())
-            case 16: return(CommandSet.UINT16())
-            case 32: return(CommandSet.UINT32())
-            case  _: return(CommandSet.NoValue())
+            case  8: return(CommandSet.get_uint8())
+            case 16: return(CommandSet.get_uint16())
+            case 32: return(CommandSet.get_uint32())
+            case  _: return(CommandSet.no_value())
 
     @property
     def device_name(self) -> str:


### PR DESCRIPTION
Fixed errors that existed due to usage of UINT instead of get_u functions in PodCommands and BasicPodProtocol